### PR TITLE
Remove python-dev from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,5 @@ pygltflib
 xatlas
 scikit-image
 accelerate
-python-dev
 pygit2
 realesrgan


### PR DESCRIPTION
Removed 'python-dev' from the requirements as it is not a valid way to install it:

```
(comfy) root@6d7df327ea87:/ComfyUI# /opt/conda/envs/comfy/bin/python -m uv pip install python-dev
Using Python 3.12.12 environment at: /opt/conda/envs/comfy
  × No solution found when resolving dependencies:
  ╰─▶ Because python-dev was not found in the package registry and you require python-dev, we can conclude that your requirements are unsatisfiable.
```